### PR TITLE
Security: Replace insecure Git credential helper

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -72,7 +72,9 @@
 	precomposeunicode = true
 	whitespace = trailing-space,space-before-tab,tab-in-indent
 [credential]
-	helper = "!f() { echo username=yon; echo \"password=$GH_AUTH_TOKEN\"; };f"
+	# Use GitHub CLI's credential manager for secure authentication
+	# Setup with: gh auth setup-git
+	helper = cache --timeout=3600
 [fetch]
 	prune = true
 [pull]


### PR DESCRIPTION
## Summary
- Replaces custom credential helper that exposes `GH_AUTH_TOKEN` with Git's secure credential cache
- Addresses high-priority security finding from security audit

## Security Impact
**Before:** Git config contained a function that directly exposed the GitHub authentication token
**After:** Uses Git's built-in credential cache with 1-hour timeout

## Changes
- Replaced custom credential helper with `cache --timeout=3600`
- Added comments explaining the secure setup process
- Recommends using GitHub CLI's `gh auth setup-git` for integration

## Test Plan
- [ ] Run `gh auth setup-git` to configure GitHub CLI authentication
- [ ] Verify Git operations work without exposing tokens
- [ ] Confirm credentials expire after 1 hour of inactivity

🤖 Generated with [Claude Code](https://claude.ai/code)