### PR TITLE
Fix zsh completion corruption and keybinding errors

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -89,16 +89,13 @@ mise() {
     fi
 }
 
-if [ -f '/opt/homebrew/share/google-cloud-sdk/completion.zsh.inc' ]; then . '/opt/homebrew/share/google-cloud-sdk/completion.zsh.inc'; fi
-
-# Initialize completions
+# Initialize completions first, before any other scripts
 autoload -Uz compinit
-# Rebuild completions if dump file is corrupted
-if [[ ! -f ~/.zcompdump ]] || ! zcompile -t ~/.zcompdump 2>/dev/null; then
-    compinit
-else
-    compinit -C
-fi
+# Always skip the dump file - it's consistently corrupted on this system
+compinit -D
+
+# Now load Google Cloud SDK completions (after compinit)
+if [ -f '/opt/homebrew/share/google-cloud-sdk/completion.zsh.inc' ]; then . '/opt/homebrew/share/google-cloud-sdk/completion.zsh.inc'; fi
 
 [ -r ${HOME}/.aliases ] && . ${HOME}/.aliases;
 [ -r ${HOME}/.functions ] && . ${HOME}/.functions;

--- a/.zshrc
+++ b/.zshrc
@@ -93,8 +93,12 @@ if [ -f '/opt/homebrew/share/google-cloud-sdk/completion.zsh.inc' ]; then . '/op
 
 # Initialize completions
 autoload -Uz compinit
-# Use a null device for zcompdump to avoid corruption issues
-compinit -d /dev/null
+# Rebuild completions if dump file is corrupted
+if [[ ! -f ~/.zcompdump ]] || ! zcompile -t ~/.zcompdump 2>/dev/null; then
+    compinit
+else
+    compinit -C
+fi
 
 [ -r ${HOME}/.aliases ] && . ${HOME}/.aliases;
 [ -r ${HOME}/.functions ] && . ${HOME}/.functions;


### PR DESCRIPTION
## Summary
- Fixed zsh startup errors caused by corrupted completion dump file
- Resolved loading order issue with Google Cloud SDK completions
- Used `compinit -D` to skip the problematic dump file

## Problem
The `.zcompdump` file was consistently getting corrupted with malformed bindkey entries, causing:
- Multiple "undefined-key" errors on zsh startup
- Tab completion failures
- The dump file had truncated command names in bindkey statements

## Solution
1. Load completions first, before any other scripts (especially Google Cloud SDK)
2. Use `compinit -D` to skip creating/reading the dump file entirely
3. This trades a tiny bit of startup time for reliability

## Test plan
- [x] Start new zsh session - no "undefined-key" errors
- [x] Tab completion works properly
- [x] No `.zcompdump` file is created (avoiding corruption)

🤖 Generated with [Claude Code](https://claude.com/claude-code)